### PR TITLE
use global pandoc installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN set -x \
 
 # Install Pandoc and required packages
   && cabal update \
-  && cabal install \
+  && cabal install --global \
   pandoc-${PANDOC_VERSION} \
   pandoc-citeproc \
   pandoc-citeproc-preamble \
@@ -47,6 +47,6 @@ RUN set -x \
 WORKDIR /data
 VOLUME ["/data"]
 
-ENTRYPOINT ["/root/.cabal/bin/pandoc"]
+ENTRYPOINT ["pandoc"]
 
 CMD ["--help"]


### PR DESCRIPTION
We should use a global installation of pandoc in order to use "-u" switch of docker. With a global installation we could execute commands like:

```bash
docker run -u $(id -u) --rm -v $(pwd):/data cloudogu/pandoc ...
```

The command above would create the output of pandoc with the uid of the executing user instead of root.